### PR TITLE
Increase dependency update interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,6 @@ updates:
   - package-ecosystem: npm
     directory: '/'
     schedule:
-      interval: weekly
+      interval: monthly
       time: '03:00'
       timezone: Europe/Berlin


### PR DESCRIPTION
Constant dependency updates on this repo are mostly overkill, as we only use the deployed endpoint where dependencies do not matter with everything compiled. Nobody uses this repo as a dependency like ocean.js. So increase update interval.